### PR TITLE
Bump to Pester 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,23 @@ cd "bosh-psmodules\module\BOSH.<module>"
 Invoke-Pester
 ```
 
-## Running a subset of tests on MacOS
+
+### Running tests via Concourse
+
+```
+# Set as appropriate for your machine
+GREENHOUSE_CI_DIR="$HOME/Workspace/github.com/cloudfoundry/greenhouse-ci"
+PSMODULES_DIR="$HOME/Workspace/github.com/cloudfoundry/bosh-psmodules"
+
+fly -t bosh-ecosystem execute \
+    --tag=windows-nimbus \
+    --config "$GREENHOUSE_CI_DIR/tasks/test-units-bosh-psmodules/task.yml" \
+    --inputs-from=windows-2019-stemcell/test-bosh-psmodules \
+    --input=bosh-psmodules-repo="$PSMODULES_DIR" \
+    --input=ci="$GREENHOUSE_CI_DIR"
+```
+
+### Running a subset of tests on MacOS
 
 You can use Powershell and MacOS to run the tests that do not require Windows system calls:
 
@@ -51,3 +67,32 @@ Import-Module ./Pester/Pester.psm1
 cd stembuild/module/BOSH.<module>
 Invoke-Pester
 ```
+
+## Debugging
+
+You can debug powershell scripts using VSCode. It has some dependencies:
+- dotnet runtime `brew install dotnet`
+- powershell binary `brew install powershell`
+- vscode extensions: `Powershell`, `C#` and `C# Dev Kit` (the latter may not be required)
+
+You can create a launch.json file like:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "PowerShell: Run Pester Tests",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "Invoke-Pester",
+            "createTemporaryIntegratedConsole": true,
+            "attachDotnetDebugger": true,
+            "cwd": "${file}"
+        }
+    ]
+}
+```
+
+And you should be able to run tests for a single file using the debug view. If you're missing extensions 
+you'll see odd failures such as the wrong CWD leading to import failures.

--- a/modules/BOSH.Account/BOSH.Account.Tests.ps1
+++ b/modules/BOSH.Account/BOSH.Account.Tests.ps1
@@ -1,27 +1,30 @@
-Remove-Module -Name BOSH.Account -ErrorAction Ignore
-Import-Module ./BOSH.Account.psm1
+BeforeAll {
+    Remove-Module -Name BOSH.Account -ErrorAction Ignore
+    Import-Module ./BOSH.Account.psm1
 
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore
-Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+    Remove-Module -Name BOSH.Utils -ErrorAction Ignore
+    Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+}
 
 Describe "Account" {
-
     Context "when username is not provided" {
         It "throws" {
-            { Add-Account } | Should Throw "Provide a user name"
+            { Add-Account } | Should -Throw "Provide a user name"
         }
     }
 
     Context "when password is not provided" {
         It "throws" {
-            { Add-Account -User hello } | Should Throw "Provide a password"
+            { Add-Account -User hello } | Should -Throw "Provide a password"
         }
     }
 
     Context "when the username and password are valid" {
-        $timestamp=(get-date -UFormat "%s" -Millisecond 0)
-        $user = "TestUser_$timestamp"
-        $password = "Password123!"
+        BeforeAll {
+            $timestamp=(get-date -UFormat "%s" -Millisecond 0)
+            $user = "TestUser_$timestamp"
+            $password = "Password123!"
+        }
 
          BeforeEach {
             $userExists = !!(Get-LocalUser | Where {$_.Name -eq $user})
@@ -34,14 +37,11 @@ Describe "Account" {
             Add-Account -User $user -Password $password
             mkdir "C:\Users\$user" -ErrorAction Ignore
             $adsi = [ADSI]"WinNT://$env:COMPUTERNAME"
-            $existing = $adsi.Children | where {$_.SchemaClassName -eq 'user' -and $_.Name -eq $user }
-            $existing | Should Not Be $null
+            $existing = $adsi.Children | Where-Object {$_.SchemaClassName -eq 'user' -and $_.Name -eq $user }
+            $existing | Should -Not -Be $null
             Remove-Account -User $user
-            $existing = $adsi.Children | where {$_.SchemaClassName -eq 'user' -and $_.Name -eq $user }
-            $existing | Should Be $null
+            $existing = $adsi.Children | Where-Object {$_.SchemaClassName -eq 'user' -and $_.Name -eq $user }
+            $existing | Should -Be $null
         }
     }
 }
-
-Remove-Module -Name BOSH.Account -ErrorAction Ignore
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore

--- a/modules/BOSH.Agent/BOSH.Agent.Tests.ps1
+++ b/modules/BOSH.Agent/BOSH.Agent.Tests.ps1
@@ -1,14 +1,17 @@
-Remove-Module -Name BOSH.Agent -ErrorAction Ignore
-Import-Module ./BOSH.Agent.psm1
+BeforeAll {
+    Remove-Module -Name BOSH.Agent -ErrorAction Ignore
+    Import-Module ./BOSH.Agent.psm1
 
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore
-Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+    Remove-Module -Name BOSH.Utils -ErrorAction Ignore
+    Import-Module ../BOSH.Utils/BOSH.Utils.psm1
 
-function New-TempDir {
-    $parent = [System.IO.Path]::GetTempPath()
-    [string] $name = [System.Guid]::NewGuid()
-    (New-Item -ItemType Directory -Path (Join-Path $parent $name)).FullName
+    function New-TempDir {
+        $parent = [System.IO.Path]::GetTempPath()
+        [string] $name = [System.Guid]::NewGuid()
+        (New-Item -ItemType Directory -Path (Join-Path $parent $name)).FullName
+    }
 }
+
 
 Describe "Copy-Agent" {
     BeforeEach {
@@ -24,37 +27,37 @@ Describe "Copy-Agent" {
 
     Context "when installDir is not provided" {
         It "throws" {
-            { Copy-Agent -agentZipPath $agentZipPath } | Should Throw "Provide a directory to install the BOSH agent"
+            { Copy-Agent -agentZipPath $agentZipPath } | Should -Throw "Provide a directory to install the BOSH agent"
         }
     }
 
     Context "when agentZipPath is not provided" {
         It "throws" {
-            { Copy-Agent -installDir $installDir } | Should Throw "Provide the path to the BOSH agent zipfile"
+            { Copy-Agent -installDir $installDir } | Should -Throw "Provide the path to the BOSH agent zipfile"
         }
     }
 
     It "creates required directories" {
-        { Copy-Agent -installDir $installDir -agentZipPath $agentZipPath } | Should Not Throw
-        Test-Path $boshDir -PathType Container | Should Be $True
-        Test-Path $vcapDir -PathType Container | Should Be $True
-        Test-Path (Join-Path $vcapDir "bin") -PathType Container | Should Be $True
-        Test-Path (Join-Path $vcapDir "log") -PathType Container | Should Be $True
+        { Copy-Agent -installDir $installDir -agentZipPath $agentZipPath } | Should -Not -Throw
+        Test-Path $boshDir -PathType Container | Should -Be $True
+        Test-Path $vcapDir -PathType Container | Should -Be $True
+        Test-Path (Join-Path $vcapDir "bin") -PathType Container | Should -Be $True
+        Test-Path (Join-Path $vcapDir "log") -PathType Container | Should -Be $True
     }
 
     It "populates the created directories with the BOSH agent executable(s)" {
-	{ Copy-Agent -installDir $installDir -agentZipPath $agentZipPath } | Should Not Throw
-        Test-Path (Join-Path $boshDir "bosh-agent.exe") | Should Be $True
-        Test-Path (Join-Path $boshDir "service_wrapper.exe") | Should Be $True
-        Test-Path (Join-Path $boshDir "service_wrapper.xml") | Should Be $True
+	{ Copy-Agent -installDir $installDir -agentZipPath $agentZipPath } | Should -Not -Throw
+        Test-Path (Join-Path $boshDir "bosh-agent.exe") | Should -Be $True
+        Test-Path (Join-Path $boshDir "service_wrapper.exe") | Should -Be $True
+        Test-Path (Join-Path $boshDir "service_wrapper.xml") | Should -Be $True
 
         $depsDir = (Join-Path $vcapDir "bin")
-        Test-Path (Join-Path $depsDir "job-service-wrapper.exe") | Should Be $True
-        Test-Path (Join-Path $depsDir "pipe.exe") | Should Be $True
-        Test-Path (Join-Path $depsDir "tar.exe") | Should Be $True
-        Test-Path (Join-Path $depsDir "bosh-blobstore-dav.exe") | Should Be $True
-        Test-Path (Join-Path $depsDir "bosh-blobstore-s3.exe") | Should Be $True
-        Test-Path (Join-Path $depsDir "bosh-blobstore-gcs.exe") | Should Be $True
+        Test-Path (Join-Path $depsDir "job-service-wrapper.exe") | Should -Be $True
+        Test-Path (Join-Path $depsDir "pipe.exe") | Should -Be $True
+        Test-Path (Join-Path $depsDir "tar.exe") | Should -Be $True
+        Test-Path (Join-Path $depsDir "bosh-blobstore-dav.exe") | Should -Be $True
+        Test-Path (Join-Path $depsDir "bosh-blobstore-s3.exe") | Should -Be $True
+        Test-Path (Join-Path $depsDir "bosh-blobstore-gcs.exe") | Should -Be $True
     }
 }
 
@@ -70,55 +73,55 @@ Describe "Write-AgentConfig" {
 
     Context "when IaaS is not provided" {
         It "throws" {
-            { Write-AgentConfig -BoshDir $boshDir } | Should Throw "Provide an IaaS for configuration"
+            { Write-AgentConfig -BoshDir $boshDir } | Should -Throw "Provide an IaaS for configuration"
         }
     }
 
     Context "when IaaS is not supported" {
         It "throws" {
-	   { Write-AgentConfig -BoshDir $boshDir -IaaS idontexist } | Should Throw "IaaS idontexist is not supported"
+	   { Write-AgentConfig -BoshDir $boshDir -IaaS idontexist } | Should -Throw "IaaS idontexist is not supported"
         }
     }
 
     Context "when boshDir is not provided" {
         It "throws" {
-            { Write-AgentConfig -IaaS aws } | Should Throw "Provide a directory to install the BOSH agent config"
+            { Write-AgentConfig -IaaS aws } | Should -Throw "Provide a directory to install the BOSH agent config"
         }
     }
 
     Context "when provided a nonexistent directory" {
         It "throws" {
-            { Write-AgentConfig -BoshDir "nonexistent-dir" -IaaS aws } | Should Throw "Error: nonexistent-dir does not exist"
+            { Write-AgentConfig -BoshDir "nonexistent-dir" -IaaS aws } | Should -Throw "Error: nonexistent-dir does not exist"
         }
     }
 
     Context "when IaaS is 'aws'" {
         It "writes the agent config for aws" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS aws } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS aws } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
         }
 
         It "enables ephemeral disk mounting by default" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS aws } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS aws } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch 'EnableEphemeralDiskMounting'
         }
 
         It "enables ephemeral disk mounting when the flag is true" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS aws -EnableEphemeralDiskMounting $true } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS aws -EnableEphemeralDiskMounting $true } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch ([regex]::New('"EnableEphemeralDiskMounting":\s*true'))
         }
     }
 
     Context "when IaaS is 'openstack'" {
         It "writes the agent config for openstack" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS openstack } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS openstack } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch ([regex]::Escape('"SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key/"'))
             ($configPath) | Should -FileContentMatch ([regex]::Escape('"UseServerName": true'))
         }
@@ -126,70 +129,70 @@ Describe "Write-AgentConfig" {
 
     Context "when IaaS is 'azure'" {
         It "writes the agent config for azure" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS azure } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS azure } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             $configContent = $(Get-Content $configPath | ConvertFrom-JSON)
 
-            $configContent.Infrastructure.Settings.Sources[0].SettingsPath | Should Be "C:/AzureData/CustomData.bin"
-            $configContent.Infrastructure.Settings.Sources[0].MetaDataPath | Should Be "C:/AzureData/CustomData.bin"
-            $configContent.Infrastructure.Settings.UseServerName | Should Be "false"
+            $configContent.Infrastructure.Settings.Sources[0].SettingsPath | Should -Be "C:/AzureData/CustomData.bin"
+            $configContent.Infrastructure.Settings.Sources[0].MetaDataPath | Should -Be "C:/AzureData/CustomData.bin"
+            $configContent.Infrastructure.Settings.UseServerName | Should -Be "false"
         }
 
         It "enables ephemeral disk mounting when the flag is true" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS azure -EnableEphemeralDiskMounting $true } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS azure -EnableEphemeralDiskMounting $true } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             $configContent = $(Get-Content $configPath | ConvertFrom-JSON)
 
-            $configContent.Platform.Windows.EnableEphemeralDiskMounting | Should Be $true
+            $configContent.Platform.Windows.EnableEphemeralDiskMounting | Should -Be $true
         }
 
     }
 
     Context "when IaaS is 'gcp'" {
         It "writes the agent config for gcp" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch ([regex]::New('"Metadata-Flavor":\s*"Google"'))
         }
 
         It "enables ephemeral disk mounting by default" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch 'EnableEphemeralDiskMounting'
         }
 
         It "enables ephemeral disk mounting when the flag is true" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp -EnableEphemeralDiskMounting $true } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS gcp -EnableEphemeralDiskMounting $true } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch ([regex]::New('"EnableEphemeralDiskMounting":\s*true'))
         }
     }
 
     Context "when IaaS is 'vsphere'" {
         It "writes the agent config for vsphere" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             $configContent = $(Get-Content $configPath | ConvertFrom-JSON)
-            $configContent.Infrastructure.Settings.Sources[0].Type | Should Be "CDROM"
+            $configContent.Infrastructure.Settings.Sources[0].Type | Should -Be "CDROM"
         }
 
         It "enables ephemeral disk mounting by default" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch 'EnableEphemeralDiskMounting'
         }
 
         It "enables ephemeral disk mounting when the flag is true" {
-            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere -EnableEphemeralDiskMounting $true } | Should Not Throw
+            { Write-AgentConfig -BoshDir $boshDir -IaaS vsphere -EnableEphemeralDiskMounting $true } | Should -Not -Throw
             $configPath = (Join-Path $boshDir "agent.json")
-            Test-Path $configPath | Should Be $True
+            Test-Path $configPath | Should -Be $True
             ($configPath) | Should -FileContentMatch ([regex]::New('"EnableEphemeralDiskMounting":\s*true'))
         }
     }
@@ -207,21 +210,21 @@ Describe "Set-Path" {
     }
 
     It "sets the system path" {
-        { Set-Path -Path $tempDir} | Should Not Throw
+        { Set-Path -Path $tempDir} | Should -Not -Throw
         $path = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-        $path | Should Match ([regex]::Escape($tempDir))
+        $path | Should -Match ([regex]::Escape($tempDir))
     }
 
     Context "when not provided a path to add" {
         It "throws" {
-            { Set-Path } | Should Throw "Error: Provide a directory to add to the path"
+            { Set-Path } | Should -Throw "Error: Provide a directory to add to the path"
         }
     }
 }
 
 Describe "Install-Agent" {
     It "calls service_wrapper.exe" {
-        Mock -Verifiable -ModuleName BOSH.Agent Start-Process {} -ParameterFilter { $FilePath -eq "C:\bosh\service_wrapper.exe" -and $ArgumentList -eq "install" -and $NoNewWindow -and $Wait }
+        Mock -ModuleName BOSH.Agent -Verifiable Start-Process {} -ParameterFilter { $FilePath -eq "C:\bosh\service_wrapper.exe" -and $ArgumentList -eq "install" -and $NoNewWindow -and $Wait }
         Install-AgentService
         Assert-VerifiableMock
     }
@@ -230,29 +233,29 @@ Describe "Install-Agent" {
 Describe "Install-Agent" {
     Context "when IaaS is not provided" {
         It "throws" {
-            { Install-Agent -agentZipPath "some-agent-zip-path" } | Should Throw "Provide the IaaS of your VM"
+            { Install-Agent -agentZipPath "some-agent-zip-path" } | Should -Throw "Provide the IaaS of your VM"
         }
     }
     Context "when agent.zip is not provided" {
         It "throws" {
-            { Install-Agent -IaaS "some-Iaas" } | Should Throw "Provide the path of your agent.zip"
+            { Install-Agent -IaaS "some-Iaas" } | Should -Throw "Provide the path of your agent.zip"
         }
     }
 
     Context "windows 2012R2" {
         It "calls helper functions with default arguments" {
-            Mock Get-OSVersion { "windows2012R2" } -ModuleName BOSH.Agent
-            Mock Test-Path { $true } -ModuleName BOSH.Agent
+            Mock -ModuleName BOSH.Agent Get-OSVersion { "windows2012R2" }
+            Mock -ModuleName BOSH.Agent Test-Path { $true }
 
-            Mock -Verifiable -ModuleName BOSH.Agent Copy-Agent {} -ParameterFilter { $InstallDir -eq "C:\" -and $agentZipPath -eq "some-agent-zip-path" }
+            Mock -ModuleName BOSH.Agent -Verifiable Copy-Agent {} -ParameterFilter { $InstallDir -eq "C:\" -and $agentZipPath -eq "some-agent-zip-path" }
 
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $path -eq "C:\bosh" }
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $path -eq "C:\var" }
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $path -eq "C:\Windows\Panther" -and $disableInheritance -eq $false }
+            Mock -ModuleName BOSH.Agent -Verifiable Protect-Dir {} -ParameterFilter { $path -eq "C:\bosh" }
+            Mock -ModuleName BOSH.Agent -Verifiable Protect-Dir {} -ParameterFilter { $path -eq "C:\var" }
+            Mock -ModuleName BOSH.Agent -Verifiable Protect-Dir {} -ParameterFilter { $path -eq "C:\Windows\Panther" -and $disableInheritance -eq $false }
 
-            Mock -Verifiable -ModuleName BOSH.Agent Write-AgentConfig {} -ParameterFilter { $IaaS -eq "aws" -and $BoshDir -eq "C:\bosh" -and $EnableEphemeralDiskMounting -eq $false }
-            Mock -Verifiable -ModuleName BOSH.Agent Set-Path {} -ParameterFilter { $Path -eq "C:\var\vcap\bosh\bin" }
-            Mock -Verifiable -ModuleName BOSH.Agent Install-AgentService {}
+            Mock -ModuleName BOSH.Agent Write-AgentConfig {} -Verifiable -ParameterFilter { $IaaS -eq "aws" -and $BoshDir -eq "C:\bosh" -and $EnableEphemeralDiskMounting -eq $false }
+            Mock -ModuleName BOSH.Agent Set-Path {} -Verifiable -ParameterFilter { $Path -eq "C:\var\vcap\bosh\bin" }
+            Mock -ModuleName BOSH.Agent Install-AgentService {} -Verifiable
 
             Install-Agent -IaaS aws -agentZipPath "some-agent-zip-path"
 
@@ -263,17 +266,17 @@ Describe "Install-Agent" {
 
     Context "windows 2016" {
         It "calls helper functions with default arguments" {
-            Mock Get-OSVersion { "window2016" } -ModuleName BOSH.Agent
-            Mock Test-Path { $true } -ModuleName BOSH.Agent
+            Mock -ModuleName BOSH.Agent Get-OSVersion { "window2016" }
+            Mock -ModuleName BOSH.Agent Test-Path { $true }
 
-            Mock -Verifiable -ModuleName BOSH.Agent Copy-Agent {} -ParameterFilter { $InstallDir -eq "C:\" -and $agentZipPath -eq "some-agent-zip-path" }
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $Path -eq "C:\bosh" }
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $Path -eq "C:\var" }
-            Mock -Verifiable -ModuleName BOSH.Agent Protect-Dir {} -ParameterFilter { $Path -eq "C:\Windows\Panther" -and $disableInheritance -eq $false }
+            Mock -ModuleName BOSH.Agent Copy-Agent {} -Verifiable -ParameterFilter { $InstallDir -eq "C:\" -and $agentZipPath -eq "some-agent-zip-path" }
+            Mock -ModuleName BOSH.Agent Protect-Dir {} -Verifiable -ParameterFilter { $Path -eq "C:\bosh" }
+            Mock -ModuleName BOSH.Agent Protect-Dir {} -Verifiable -ParameterFilter { $Path -eq "C:\var" }
+            Mock -ModuleName BOSH.Agent Protect-Dir {} -Verifiable -ParameterFilter { $Path -eq "C:\Windows\Panther" -and $disableInheritance -eq $false }
 
-            Mock -Verifiable -ModuleName BOSH.Agent Write-AgentConfig {} -ParameterFilter { $IaaS -eq "aws" -and $BoshDir -eq "C:\bosh" -and $EnableEphemeralDiskMounting -eq $true }
-            Mock -Verifiable -ModuleName BOSH.Agent Set-Path {} -ParameterFilter { $Path -eq "C:\var\vcap\bosh\bin" }
-            Mock -Verifiable -ModuleName BOSH.Agent Install-AgentService {}
+            Mock -ModuleName BOSH.Agent Write-AgentConfig {} -Verifiable -ParameterFilter { $IaaS -eq "aws" -and $BoshDir -eq "C:\bosh" -and $EnableEphemeralDiskMounting -eq $true }
+            Mock -ModuleName BOSH.Agent Set-Path {} -Verifiable -ParameterFilter { $Path -eq "C:\var\vcap\bosh\bin" }
+            Mock -ModuleName BOSH.Agent Install-AgentService {} -Verifiable
 
             Install-Agent -IaaS aws -agentZipPath "some-agent-zip-path"
 
@@ -282,6 +285,3 @@ Describe "Install-Agent" {
         }
     }
 }
-
-Remove-Module -Name BOSH.Agent -ErrorAction Ignore
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore

--- a/modules/BOSH.CFCell/BOSH.CFCell.Tests.ps1
+++ b/modules/BOSH.CFCell/BOSH.CFCell.Tests.ps1
@@ -1,69 +1,72 @@
-Remove-Module -Name BOSH.CFCell -ErrorAction Ignore
-Import-Module ./BOSH.CFCell.psm1
+BeforeAll {
+    Remove-Module -Name BOSH.CFCell -ErrorAction Ignore
+    Import-Module ./BOSH.CFCell.psm1
 
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore
-Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+    Remove-Module -Name BOSH.Utils -ErrorAction Ignore
+    Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+}
 
 Describe "Protect-CFCell" {
     BeforeEach {
         $oldWinRMStatus = (Get-Service winrm).Status
         $oldWinRMStartMode = ( Get-Service winrm ).StartType
 
-        { Set-Service -Name "winrm" -StartupType "Manual" } | Should Not Throw
+        { Set-Service -Name "winrm" -StartupType "Manual" } | Should -Not -Throw
 
         Start-Service winrm
     }
 
     AfterEach {
         if ($oldWinRMStatus -eq "Stopped") {
-            { Stop-Service winrm } | Should Not Throw
+            { Stop-Service winrm } | Should -Not -Throw
         } else {
-            { Set-Service -Name "winrm" -Status $oldWinRMStatus } | Should Not Throw
+            { Set-Service -Name "winrm" -Status $oldWinRMStatus } | Should -Not -Throw
         }
-        { Set-Service -Name "winrm" -StartupType $oldWinRMStartMode } | Should Not Throw
+        { Set-Service -Name "winrm" -StartupType $oldWinRMStartMode } | Should -Not -Throw
     }
 
     It "disables the RDP service and firewall rule" {
        Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Terminal Server" -Name "fDenyTSConnections" -Value 0
        Get-NetFirewallRule -DisplayName "Remote Desktop*" | Set-NetFirewallRule -enabled true
        Get-Service "Termservice" | Set-Service -StartupType "Automatic"
-       netstat /p tcp /a | findstr ":3389 " | Should Not BeNullOrEmpty
+       netstat /p tcp /a | findstr ":3389 " | Should -Not -BeNullOrEmpty
 
        Protect-CFCell
 
-       Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Terminal Server" | select -exp fDenyTSConnections | Should Be 1
-       netstat /p tcp /a | findstr ":3389 " | Should BeNullOrEmpty
-       Get-NetFirewallRule -DisplayName "Remote Desktop*" | ForEach { $_.enabled | Should be "False" }
-       Get-Service "Termservice" | Select -exp starttype | Should Be "Disabled"
+       Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Terminal Server" | select -exp fDenyTSConnections | Should -Be 1
+       netstat /p tcp /a | findstr ":3389 " | Should -BeNullOrEmpty
+       Get-NetFirewallRule -DisplayName "Remote Desktop*" | ForEach { $_.enabled | Should -Be "False" }
+       Get-Service "Termservice" | Select -exp starttype | Should -Be "Disabled"
     }
 
     It "disables the services" {
        Get-Service | Where-Object {$_.Name -eq "WinRM" } | Set-Service -StartupType Automatic
        Get-Service | Where-Object {$_.Name -eq "W3Svc" } | Set-Service -StartupType Automatic
        Protect-CFCell
-       (Get-Service | Where-Object {$_.Name -eq "WinRM" } ).StartType| Should be "Disabled"
+       (Get-Service | Where-Object {$_.Name -eq "WinRM" } ).StartType| Should -Be "Disabled"
        $w3svcStartType = (Get-Service | Where-Object {$_.Name -eq "W3Svc" } ).StartType
-       "Disabled", $null -contains $w3svcStartType | Should Be $true
+       "Disabled", $null -contains $w3svcStartType | Should -Be $true
     }
 
     It "sets firewall rules" {
         Set-NetFirewallProfile -all -DefaultInboundAction Allow -DefaultOutboundAction Allow -AllowUnicastResponseToMulticast False -Enabled True
-        get-firewall "public" | Should be "public,Allow,Allow"
-        get-firewall "private" | Should be "private,Allow,Allow"
-        get-firewall "domain" | Should be "domain,Allow,Allow"
+        get-firewall "public" | Should -Be "public,Allow,Allow"
+        get-firewall "private" | Should -Be "private,Allow,Allow"
+        get-firewall "domain" | Should -Be "domain,Allow,Allow"
         Protect-CFCell
-        get-firewall "public" | Should be "public,Block,Allow"
-        get-firewall "private" | Should be "private,Block,Allow"
-        get-firewall "domain" | Should be "domain,Block,Allow"
+        get-firewall "public" | Should -Be "public,Block,Allow"
+        get-firewall "private" | Should -Be "private,Block,Allow"
+        get-firewall "domain" | Should -Be "domain,Block,Allow"
     }
 }
 
 Describe "Install-CFFeatures" {
     It "restarts computer on Microsoft server 2016 and later" {
-        Mock Install-CFFeatures2012 { } -ModuleName BOSH.CFCell
-        Mock Install-CFFeatures2016 { } -ModuleName BOSH.CFCell
-        Mock Write-Error { } -ModuleName BOSH.CFCell
-        Mock Get-WmiObject { New-Object PSObject -Property @{Version = "10.0.1803"} } -ModuleName BOSH.CFCell
+
+        Mock -ModuleName BOSH.CFCell Install-CFFeatures2012 { }
+        Mock -ModuleName BOSH.CFCell Install-CFFeatures2016 { }
+        Mock -ModuleName BOSH.CFCell Write-Error { }
+        Mock -ModuleName BOSH.CFCell Get-OSVersionString { "10.0.1803" }
 
         { Install-CFFeatures } | Should -Not -Throw
 
@@ -74,12 +77,15 @@ Describe "Install-CFFeatures" {
 
 Describe "Install-CFFeatures2016" {
     BeforeEach {
-        Mock Write-Log { } -ModuleName BOSH.CFCell
-        Mock Get-WinRMConfig { "Some config" } -ModuleName BOSH.CFCell
-        Mock WindowsFeatureInstall { } -ModuleName BOSH.CFCell
-        Mock Remove-WindowsFeature { } -ModuleName BOSH.CFCell
-        Mock Set-Service { } -ModuleName BOSH.CFCell
-        Mock Restart-Computer { } -ModuleName BOSH.CFCell
+        Mock -ModuleName BOSH.CFCell Write-Log { }
+        Mock -ModuleName BOSH.CFCell Get-WinRMConfig { "Some config" }
+        Mock -ModuleName BOSH.CFCell WindowsFeatureInstall { }
+        Mock Uninstall-WindowsFeature { }
+        Mock -ModuleName BOSH.CFCell Uninstall-WindowsFeature { }
+        Mock -ModuleName BOSH.CFCell Set-Service { }
+        # Mock Set-Service { }
+        Mock -ModuleName BOSH.CFCell Restart-Computer { }
+        Mock -ModuleName BOSH.CFCell Get-OSVersionString { "10.0.1803" }
     }
 
     It "triggers a machine restart when the -ForceReboot flag is set" {
@@ -105,18 +111,17 @@ Describe "Install-CFFeatures2016" {
 
         Assert-MockCalled Write-Log -Times 1 -Scope It -ModuleName BOSH.CFCell -ParameterFilter { $Message -eq "Installed CloudFoundry Cell Windows Features" }
     }
-
 }
 
 Describe "Remove-DockerPackage" {
     It "Is impossible to test this" {
         # Pest has issues mocking functions that use validateSet See: https://github.com/pester/Pester/issues/734
-#        Mock Uninstall-Package { } -ModuleName BOSH.CFCell
-#        Mock Write-Log { } -ModuleName BOSH.CFCell
-#        Mock Uninstall-Module { } -ParameterFilter { $Name -eq "DockerMsftProvider" -and $ErrorAction -eq "Ignore" } -ModuleName BOSH.CFCell
-#        Mock Get-HNSNetwork { "test-network" } -ModuleName BOSH.CFCell
-#        Mock Remove-HNSNetwork { } -ModuleName BOSH.CFCell
-#        Mock remove-DockerProgramData { } -ModuleName BOSH.CFCell
+#        Mock -ModuleName BOSH.CFCell Uninstall-Package { }
+#        Mock -ModuleName BOSH.CFCell Write-Log { }
+#        Mock -ModuleName BOSH.CFCell Uninstall-Module { } -ParameterFilter { $Name -eq "DockerMsftProvider" -and $ErrorAction -eq "Ignore" }
+#        Mock -ModuleName BOSH.CFCell Get-HNSNetwork { "test-network" }
+#        Mock -ModuleName BOSH.CFCell Remove-HNSNetwork { }
+#        Mock -ModuleName BOSH.CFCell remove-DockerProgramData { }
 #
 #        { Remove-DockerPackage } | Should -Not -Throw
 #
@@ -128,5 +133,3 @@ Describe "Remove-DockerPackage" {
     }
 }
 
-Remove-Module -Name BOSH.CFCell -ErrorAction Ignore
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore

--- a/modules/BOSH.CFCell/BOSH.CFCell.psm1
+++ b/modules/BOSH.CFCell/BOSH.CFCell.psm1
@@ -1,12 +1,16 @@
-﻿<#
+﻿# function Get-OSVersionStringg {
+#   return [System.Environment]::OSVersion.Version.ToString()
+# }
+
+<#
 .Synopsis
     Install CloudFoundry Cell components for either 2012R2 or 2016
 .Description
     This cmdlet installs the minimum set of features for a CloudFoundry Cell on Windows 2012R2 or Windows 2016
 #>
 function Install-CFFeatures {
-  $OS = Get-WmiObject Win32_OperatingSystem
-  switch -Wildcard ($OS.Version) {
+  $VERSION = Get-OSVersionString
+  switch -Wildcard ($VERSION) {
     "6.3.*" {
       Install-CFFeatures2012
     }
@@ -14,7 +18,7 @@ function Install-CFFeatures {
       Install-CFFeatures2016 -ForceReboot
     }
     default {
-      Write-Error "Unsupported Windows version $($OS.Version)"
+      Write-Error "Unsupported Windows version $($VERSION)"
     }
   }
 }

--- a/modules/BOSH.Registry/BOSH.Registry.Tests.ps1
+++ b/modules/BOSH.Registry/BOSH.Registry.Tests.ps1
@@ -1,17 +1,18 @@
-Remove-Module -Name BOSH.Registry -ErrorAction Ignore
-Import-Module ./BOSH.Registry.psm1
+BeforeAll {
+    Import-Module ./BOSH.Registry.psm1
+}
 
 Describe "BOSH.Registry" {
     BeforeEach {
         $newItemReturn = [pscustomobject]@{"NewPath" = "HKCU:/Path/created";}
-        Mock New-Item { $newItemReturn } -ModuleName BOSH.Registry
+        Mock -ModuleName BOSH.Registry New-Item { $newItemReturn }
         # reset for our -parameterfilter mock
-        Mock New-Item { $newItemReturn } -ModuleName BOSH.Registry -ParameterFilter { $PSBoundParameters['ErrorAction'] -eq "Stop" }
+#        Mock -ModuleName BOSH.Registry New-Item { $newItemReturn } -ParameterFilter { $PSBoundParameters['ErrorAction'] -eq "Stop" }
     }
 
     It "Set-InternetExplorerRegistries applies internet explorer settings when valid policy files are generated" {
-        Mock Invoke-LGPO-Build-Pol-From-Text { 0 } -ModuleName BOSH.Registry
-        Mock Invoke-LGPO-Apply-Policies  { 0 } -ModuleName BOSH.Registry
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text { 0 }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies  { 0 }
 
         Set-InternetExplorerRegistries
 
@@ -19,64 +20,69 @@ Describe "BOSH.Registry" {
         Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 1 -Scope It -ModuleName BOSH.Registry
     }
     It "Set-InternetExplorerRegistries errors out when policy application fails" {
-        Mock Invoke-LGPO-Build-Pol-From-Text { 0 } -ModuleName BOSH.Registry
-        Mock Invoke-LGPO-Apply-Policies  { 1 } -ModuleName BOSH.Registry
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text { 0 }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies  { 1 }
 
-        { Set-InternetExplorerRegistries } | Should -Throw "Error Applying IE policy:"
+        { Set-InternetExplorerRegistries } | Should -Throw "Error Applying IE policy:*"
 
         Assert-MockCalled Invoke-LGPO-Build-Pol-From-Text -Exactly 2 -Scope It -ModuleName BOSH.Registry
         Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 1 -Scope It -ModuleName BOSH.Registry
     }
 
     It "Set-InternetExplorerRegistries errors out when User policy generation fails and does not attempt policy application" {
-        Mock Invoke-LGPO-Build-Pol-From-Text { 0 } -ModuleName BOSH.Registry -ParameterFilter {
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text { 0 } -ParameterFilter {
             $LGPOTextReadPath -like "*machine.txt"
         }
-        Mock Invoke-LGPO-Build-Pol-From-Text { 1 } -ModuleName BOSH.Registry -ParameterFilter {
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text { 1 } -ParameterFilter {
             $LGPOTextReadPath -like "*user.txt"
         }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies
 
         { Set-InternetExplorerRegistries } | Should -Throw "Generating IE policy: User"
 
-        Assert-MockCalled Invoke-LGPO-Build-Pol-From-Text -Exactly 2 -Scope It -ModuleName BOSH.Registry
-        Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 0 -Scope It -ModuleName BOSH.Registry
+        Should -ModuleName BOSH.Registry -Invoke Invoke-LGPO-Build-Pol-From-Text -Exactly 2
+        Should -ModuleName BOSH.Registry -Invoke Invoke-LGPO-Apply-Policies -Exactly 0
     }
 
     It "Set-InternetExplorerRegistries errors out when Machine policy generation fails and does not attempt policy application" {
-        Mock Invoke-LGPO-Build-Pol-From-Text { 1 } -ModuleName BOSH.Registry -ParameterFilter {
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text { 1 } -ParameterFilter {
             $LGPOTextReadPath -like "*machine.txt"
         }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies
 
         { Set-InternetExplorerRegistries } | Should -Throw "Generating IE policy: Machine"
 
-        Assert-MockCalled Invoke-LGPO-Build-Pol-From-Text -Exactly 1 -Scope It -ModuleName BOSH.Registry
-        Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 0 -Scope It -ModuleName BOSH.Registry
+        Should -ModuleName BOSH.Registry -Invoke Invoke-LGPO-Build-Pol-From-Text -Exactly 1
+        Should -ModuleName BOSH.Registry -Invoke Invoke-LGPO-Apply-Policies -Exactly 0
     }
 
     It "Set-InternetExplorerRegistries doesn't call Invoke-LGPO-Build-Pol-From-Text if New-Item call for Machine Directory fails" {
         # ErrorAction Parameterfilter is present to ensure we only throw an error on a New-Item call that is configured to throw errors
-        Mock New-Item { Throw 'some error' } -ModuleName BOSH.Registry -ParameterFilter {
-            $Path -like "*Machine" -and
-            $PSBoundParameters['ErrorAction'] -eq "Stop"
+        Mock -ModuleName BOSH.Registry New-Item { Throw 'some error' } -ParameterFilter {
+            $Path -like "*Machine" -and $PesterBoundParameters['ErrorAction'] -eq "Stop"
         }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies
 
         { Set-InternetExplorerRegistries } | Should -Throw
 
-        Assert-MockCalled Invoke-LGPO-Build-Pol-From-Text -Exactly 0 -Scope It -ModuleName BOSH.Registry
-        Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 0 -Scope It -ModuleName BOSH.Registry
+        Should -ModuleName BOSH.Registry -Invoke New-Item -Exactly 1
+        Should -ModuleName BOSH.Registry -Invoke Invoke-LGPO-Build-Pol-From-Text -Exactly 0
+        Should -ModuleName BOSH.Registry -Invoke  Invoke-LGPO-Apply-Policies -Exactly 0
     }
 
 
     It "Set-InternetExplorerRegistries doesn't call Invoke-LGPO-Build-Pol-From-Text if New-Item call for User Directory fails" {
         # ErrorAction Parameterfilter is present to ensure we only throw an error on a New-Item call that is configured to throw errors
-        Mock New-Item { Throw 'some error' } -ModuleName BOSH.Registry -ParameterFilter {
-            $Path -like "*User" -and
-                    $PSBoundParameters['ErrorAction'] -eq "Stop"
+        Mock -ModuleName BOSH.Registry New-Item { Throw 'some error' } -ParameterFilter {
+            $Path -like "*User" -and $PesterBoundParameters['ErrorAction'] -eq "Stop"
         }
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Build-Pol-From-Text
+        Mock -ModuleName BOSH.Registry Invoke-LGPO-Apply-Policies
 
         { Set-InternetExplorerRegistries } | Should -Throw
 
-        Assert-MockCalled Invoke-LGPO-Build-Pol-From-Text -Exactly 1 -Scope It -ModuleName BOSH.Registry
-        Assert-MockCalled Invoke-LGPO-Apply-Policies -Exactly 0 -Scope It -ModuleName BOSH.Registry
+        Should -ModuleName BOSH.Registry -Invoke  Invoke-LGPO-Build-Pol-From-Text -Exactly 1
+        Should -ModuleName BOSH.Registry -Invoke  Invoke-LGPO-Apply-Policies -Exactly 0
     }
 }

--- a/modules/BOSH.Registry/BOSH.Registry.psm1
+++ b/modules/BOSH.Registry/BOSH.Registry.psm1
@@ -48,23 +48,23 @@ function Set-InternetExplorerRegistries {
 
         $MachineDir="$IePolicyPath\DomainSysvol\GPO\Machine"
 
-        New-Item -ItemType Directory -Path $MachineDir -Force -ErrorAction "Stop"
+        New-Item -ItemType Directory -Path "$MachineDir" -Force -ErrorAction "Stop"
         $machinePolicyExitCode = Invoke-LGPO-Build-Pol-From-Text -LGPOTextReadPath "$IePolicyPath\machine.txt" -RegistryPolWritePath "$MachineDir\registry.pol"
         if ($machinePolicyExitCode -ne 0) {
-            Throw "Generating IE policy: Machine"
+            throw "Generating IE policy: Machine"
         }
 
         $UserDir="$IePolicyPath\DomainSysvol\GPO\User"
-        New-Item -ItemType Directory -Path $UserDir -Force -ErrorAction "Stop"
+        New-Item -ItemType Directory -Path "$UserDir" -Force -ErrorAction "Stop"
         $userPolicyExitCode = Invoke-LGPO-Build-Pol-From-Text -LGPOTextReadPath "$IePolicyPath\user.txt" -RegistryPolWritePath "$UserDir\registry.pol"
         if ($userPolicyExitCode -ne 0) {
-            Throw "Generating IE policy: User"
+            throw "Generating IE policy: User"
         }
 
         # Apply policies
         $policyApplicationExitCode = Invoke-LGPO-Apply-Policies -RegistryPolPath $IePolicyPath
         if ($policyApplicationExitCode -ne 0) {
-            Throw "Error Applying IE policy: $IePolicyPath"
+            throw "Error Applying IE policy: $IePolicyPath"
         }
     }
 }

--- a/modules/BOSH.Utils/BOSH.Utils.psd1
+++ b/modules/BOSH.Utils/BOSH.Utils.psd1
@@ -23,6 +23,7 @@ FunctionsToExport = @(
     'Disable-3DES',
     'Disable-DCOM',
     'Get-OSVersion',
+    'Get-OSVersionString',
     'Get-WinRMConfig',
     'Get-WUCerts',
     'New-VersionFile',

--- a/modules/BOSH.Utils/BOSH.Utils.psm1
+++ b/modules/BOSH.Utils/BOSH.Utils.psm1
@@ -311,7 +311,7 @@ function Get-OSVersion {
 function New-VersionFile {
     param([string]$Version)
 
-    if (!$Version) {
+    if ($Version -eq "") {
         throw "-Version parameter must be specified as major.minor[.whatever]"
     }
 

--- a/modules/BOSH.WindowsUpdates/BOSH.WindowsUpdates.Tests.ps1
+++ b/modules/BOSH.WindowsUpdates/BOSH.WindowsUpdates.Tests.ps1
@@ -1,17 +1,18 @@
-Remove-Module -Name BOSH.WindowsUpdates -ErrorAction Ignore
-Import-Module ./BOSH.WindowsUpdates.psm1
+BeforeAll {
+    Remove-Module -Name BOSH.WindowsUpdates -ErrorAction Ignore
+    Import-Module ./BOSH.WindowsUpdates.psm1
 
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore
-Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+    Remove-Module -Name BOSH.Utils -ErrorAction Ignore
+    Import-Module ../BOSH.Utils/BOSH.Utils.psm1
+}
 
 Describe "Disable-AutomaticUpdates" {
-
     BeforeEach {
         $oldWuauStatus = (Get-Service wuauserv).Status
         $oldWuauStartMode = ( Get-Service wuauserv ).StartType
 
-        { Set-Service -Name wuauserv -StartupType "Manual" } | Should Not Throw
-        { Set-Service -Name wuauserv -Status "Running" } | Should Not Throw
+        { Set-Service -Name wuauserv -StartupType "Manual" } | Should -Not -Throw
+        { Set-Service -Name wuauserv -Status "Running" } | Should -Not -Throw
 
 
         $oldAUOptions = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').AUOptions
@@ -21,7 +22,7 @@ Describe "Disable-AutomaticUpdates" {
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update' -Value 2 -Name 'EnableFeaturedSoftware'
         Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update' -Value 2 -Name 'IncludeRecommendedUpdates'
 
-        { Disable-AutomaticUpdates } | Should Not Throw
+        { Disable-AutomaticUpdates } | Should -Not -Throw
     }
 
     AfterEach {
@@ -43,23 +44,23 @@ Describe "Disable-AutomaticUpdates" {
             Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update' -Value $oldAUOptions -Name 'IncludeRecommendedUpdates'
         }
 
-        { Set-Service -Name wuauserv -StartupType $oldWuauStartMode } | Should Not Throw
+        { Set-Service -Name wuauserv -StartupType $oldWuauStartMode } | Should -Not -Throw
         if ($oldWuauStatus -eq "Stopped") {
             Stop-Service wuauserv
         } else {
-            { Set-Service -Name wuauserv -Status $oldWuauStatus } | Should Not Throw
+            { Set-Service -Name wuauserv -Status $oldWuauStatus } | Should -Not -Throw
         }
     }
 
     It "stops and disables the Windows Updates service" {
-        (Get-Service -Name "wuauserv").Status | Should Be "Stopped"
-        (Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='wuauserv'").StartMode | Should Be "Disabled"
+        (Get-Service -Name "wuauserv").Status | Should -Be "Stopped"
+        (Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='wuauserv'").StartMode | Should -Be "Disabled"
     }
 
     It "sets registry keys to stop automatically installing updates" {
-        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').AUOptions | Should Be "1"
-        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').EnableFeaturedSoftware | Should Be "0"
-        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').IncludeRecommendedUpdates | Should Be "0"
+        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').AUOptions | Should -Be "1"
+        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').EnableFeaturedSoftware | Should -Be "0"
+        (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update').IncludeRecommendedUpdates | Should -Be "0"
     }
 }
 
@@ -79,10 +80,10 @@ Describe "Enable-SecurityPatches" {
             $oldIExplore64 = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ALLOW_USER32_EXCEPTION_HANDLER_HARDENING").'iexplore.exe'
         }
 
-        { Enable-CVE-2015-6161 } | Should Not Throw
+        { Enable-CVE-2015-6161 } | Should -Not -Throw
 
-        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ALLOW_USER32_EXCEPTION_HANDLER_HARDENING").'iexplore.exe' | Should Be "1"
-        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ALLOW_USER32_EXCEPTION_HANDLER_HARDENING").'iexplore.exe' | Should Be "1"
+        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ALLOW_USER32_EXCEPTION_HANDLER_HARDENING").'iexplore.exe' | Should -Be "1"
+        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ALLOW_USER32_EXCEPTION_HANDLER_HARDENING").'iexplore.exe' | Should -Be "1"
 
         if ($handlerHardeningPath32Exists) {
             if ($oldIExplore32 -eq "")
@@ -122,10 +123,10 @@ Describe "Enable-SecurityPatches" {
             $oldIExplore64 = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ENABLE_PRINT_INFO_DISCLOSURE_FIX").'iexplore.exe'
         }
 
-        { Enable-CVE-2017-8529 } | Should Not Throw
+        { Enable-CVE-2017-8529 } | Should -Not -Throw
 
-        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ENABLE_PRINT_INFO_DISCLOSURE_FIX").'iexplore.exe' | Should Be "1"
-        (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ENABLE_PRINT_INFO_DISCLOSURE_FIX").'iexplore.exe' | Should Be "1"
+        (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ENABLE_PRINT_INFO_DISCLOSURE_FIX").'iexplore.exe' | Should -Be "1"
+        (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ENABLE_PRINT_INFO_DISCLOSURE_FIX").'iexplore.exe' | Should -Be "1"
 
         if ($disclosureFixPathExists32) {
             if ($oldIExplore32 -eq "")
@@ -163,9 +164,9 @@ Describe "Enable-SecurityPatches" {
             }
         }
 
-        { Enable-CredSSP } | Should Not Throw
+        { Enable-CredSSP } | Should -Not -Throw
 
-        (Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters").AllowEncryptionOracle | Should Be "1"
+        (Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters").AllowEncryptionOracle | Should -Be "1"
 
         if ($credSSPPathExists) {
             if ( $credSSPParamPathExists ) {
@@ -187,11 +188,11 @@ Describe "Enable-SecurityPatches" {
 
 Describe "Upgrade-PSVersion" {
     It "Only installs if powershell 5.1 or above is not installed" {
-        Mock Test-PSVersion { $true } -ModuleName BOSH.WindowsUpdates
-        Mock Invoke-WebRequest { } -ModuleName BOSH.WindowsUpdates
-        Mock Start-Process { } -ModuleName BOSH.WindowsUpdates
+        Mock -ModuleName BOSH.WindowsUpdates Test-PSVersion { $true }
+        Mock -ModuleName BOSH.WindowsUpdates Invoke-WebRequest { }
+        Mock -ModuleName BOSH.WindowsUpdates Start-Process { }
 
-        { Upgrade-PSVersion } | Should Not Throw
+        { Upgrade-PSVersion } | Should -Not -Throw
 
         Assert-MockCalled Test-PSVersion -Times 1 -Scope It -ModuleName BOSH.WindowsUpdates
         Assert-MockCalled Invoke-WebRequest -Times 0 -Scope It -ModuleName BOSH.WindowsUpdates
@@ -199,17 +200,14 @@ Describe "Upgrade-PSVersion" {
     }
 
     It "Only installs if powershell 5.1 or above is not installed" {
-        Mock Test-PSVersion { $false } -ModuleName BOSH.WindowsUpdates
-        Mock Invoke-WebRequest { } -ModuleName BOSH.WindowsUpdates
-        Mock Start-Process { } -ModuleName BOSH.WindowsUpdates
+        Mock -ModuleName BOSH.WindowsUpdates Test-PSVersion { $false }
+        Mock -ModuleName BOSH.WindowsUpdates Invoke-WebRequest { }
+        Mock -ModuleName BOSH.WindowsUpdates Start-Process { }
 
-        { Upgrade-PSVersion } | Should Not Throw
+        { Upgrade-PSVersion } | Should -Not -Throw
 
         Assert-MockCalled Test-PSVersion -Times 1 -Scope It -ModuleName BOSH.WindowsUpdates
         Assert-MockCalled Invoke-WebRequest -Times 1 -Scope It -ParameterFilter { $Uri -eq "https://go.microsoft.com/fwlink/?linkid=839516" -and $Outfile -eq "C:\provision\PS51.msu" -and $UseBasicParsing.IsPresent } -ModuleName BOSH.WindowsUpdates
         Assert-MockCalled Start-Process -Times 1 -Scope It -ParameterFilter { $FilePath -eq "C:\provision\PS51.msu" -and $ArgumentList -eq '/quiet /norestart /log:"C:\provision\psupgrade.log"' -and $Wait.IsPresent -and $Passthru.IsPresent } -ModuleName BOSH.WindowsUpdates
     }
 }
-
-Remove-Module -Name BOSH.WindowsUpdates -ErrorAction Ignore
-Remove-Module -Name BOSH.Utils -ErrorAction Ignore


### PR DESCRIPTION
This is super painful since pester 5 had a lot of small, subtle and otherwise small cahgnes which break back compat, like scoping, error handling and a variety of other small things.

I also did some cleanup to standardise on calling conventions and pulled in all the missed Pester 3 -> 4 changes as well.

It will also no longer try test directories with no tests, since that throws up a really ugly error.